### PR TITLE
Update instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ oc get secret external-tls-secret -n websphere-automation -o jsonpath='{.data.ce
 ```
 * Configure the server to use TLS/SSL using the provided server_tls.xml file:
 ```
-cp -f /home/ibmuser/Desktop/lab_backup/liberty200012/server_tls.xml /opt/IBM/WebSphere/Liberty200012/usr/servers/Liberty_200012_server/server.xml
+\cp -f /home/ibmuser/Desktop/lab_backup/liberty200012/server_tls.xml /opt/IBM/WebSphere/Liberty200012/usr/servers/Liberty_200012_server/server.xml
 
 ```
 
@@ -206,7 +206,7 @@ cat /opt/IBM/WebSphere/api-key.txt
 * Since you have already configured usageMetering feature for Liberty version 20.0.0.12, we have a provided couple of server.xml files to make the configuration simpler. First copy the tls configuration:
 
 ```
-cp -f /home/ibmuser/Desktop/lab_backup/liberty20009/server_tls.xml /opt/IBM/WebSphere/Liberty20009/usr/servers/Liberty_20009_server/server.xml
+\cp -f /home/ibmuser/Desktop/lab_backup/liberty20009/server_tls.xml /opt/IBM/WebSphere/Liberty20009/usr/servers/Liberty_20009_server/server.xml
 
 ```
 
@@ -232,7 +232,7 @@ keytool -import -trustcacerts -file /opt/IBM/WebSphere/cacert.pem -keystore /opt
 * Copy the server.xml that contains the usageMetering feature and properties (url, api-key):
 
 ```
-cp -f /home/ibmuser/Desktop/lab_backup/liberty20009/server_configured.xml /opt/IBM/WebSphere/Liberty20009/usr/servers/Liberty_20009_server/server.xml
+\cp -f /home/ibmuser/Desktop/lab_backup/liberty20009/server_configured.xml /opt/IBM/WebSphere/Liberty20009/usr/servers/Liberty_20009_server/server.xml
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -141,9 +141,9 @@ oc get secret external-tls-secret -n websphere-automation -o jsonpath='{.data.ce
 ```
 /opt/IBM/WebSphere/Liberty200012/bin/server create Liberty_200012_server
 ```
-* Configure the server to use TLS/SSL using the provided server_tls.xml file. Enter `y` to overwrite the existing file:
+* Configure the server to use TLS/SSL using the provided server_tls.xml file:
 ```
-cp /home/ibmuser/Desktop/lab_backup/liberty200012/server_tls.xml /opt/IBM/WebSphere/Liberty200012/usr/servers/Liberty_200012_server/server.xml
+cp -f /home/ibmuser/Desktop/lab_backup/liberty200012/server_tls.xml /opt/IBM/WebSphere/Liberty200012/usr/servers/Liberty_200012_server/server.xml
 
 ```
 
@@ -203,10 +203,10 @@ cat /opt/IBM/WebSphere/api-key.txt
 /opt/IBM/WebSphere/Liberty20009/bin/server create Liberty_20009_server
 ```
 
-* Since you have already configured usageMetering feature for Liberty version 20.0.0.12, we have a provided couple of server.xml files to make the configuration simpler. First copy the tls configuration. Enter `y` to overwrite the existing file:
+* Since you have already configured usageMetering feature for Liberty version 20.0.0.12, we have a provided couple of server.xml files to make the configuration simpler. First copy the tls configuration:
 
 ```
-cp /home/ibmuser/Desktop/lab_backup/liberty20009/server_tls.xml /opt/IBM/WebSphere/Liberty20009/usr/servers/Liberty_20009_server/server.xml
+cp -f /home/ibmuser/Desktop/lab_backup/liberty20009/server_tls.xml /opt/IBM/WebSphere/Liberty20009/usr/servers/Liberty_20009_server/server.xml
 
 ```
 
@@ -229,10 +229,10 @@ keytool -import -trustcacerts -file /opt/IBM/WebSphere/cacert.pem -keystore /opt
 
 ```
 
-* Copy the server.xml that contains the usageMetering feature and properties (url, api-key). Enter `y` to overwrite the existing file:
+* Copy the server.xml that contains the usageMetering feature and properties (url, api-key):
 
 ```
-cp /home/ibmuser/Desktop/lab_backup/liberty20009/server_configured.xml /opt/IBM/WebSphere/Liberty20009/usr/servers/Liberty_20009_server/server.xml
+cp -f /home/ibmuser/Desktop/lab_backup/liberty20009/server_configured.xml /opt/IBM/WebSphere/Liberty20009/usr/servers/Liberty_20009_server/server.xml
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -146,6 +146,12 @@ oc get secret external-tls-secret -n websphere-automation -o jsonpath='{.data.ce
 cp /home/ibmuser/Desktop/lab_backup/liberty200012/server_tls.xml /opt/IBM/WebSphere/Liberty200012/usr/servers/Liberty_200012_server/server.xml
 
 ```
+
+* Note the above command occasionally fails on the VM. Ensure that the two files are the same.
+```
+cmp /home/ibmuser/Desktop/lab_backup/liberty200012/server_tls.xml /opt/IBM/WebSphere/Liberty200012/usr/servers/Liberty_200012_server/server.xml && echo "files are the same, proceed to the next step"
+```
+
 * Start the Liberty server
 ```
 /opt/IBM/WebSphere/Liberty200012/bin/server start Liberty_200012_server
@@ -204,6 +210,12 @@ cp /home/ibmuser/Desktop/lab_backup/liberty20009/server_tls.xml /opt/IBM/WebSphe
 
 ```
 
+* Note the above command occasionally fails on the VM. Ensure that the two files are the same.
+
+```
+cmp /home/ibmuser/Desktop/lab_backup/liberty20009/server_tls.xml /opt/IBM/WebSphere/Liberty20009/usr/servers/Liberty_20009_server/server.xml && echo "files are the same, proceed to the next step"
+```
+
 * Start the Liberty server:
 
 ```
@@ -222,6 +234,12 @@ keytool -import -trustcacerts -file /opt/IBM/WebSphere/cacert.pem -keystore /opt
 ```
 cp /home/ibmuser/Desktop/lab_backup/liberty20009/server_configured.xml /opt/IBM/WebSphere/Liberty20009/usr/servers/Liberty_20009_server/server.xml
 
+```
+
+* Note the above command occasionally fails on the VM. Ensure that the two files are the same.
+
+```
+cmp /home/ibmuser/Desktop/lab_backup/liberty20009/server_configured.xml /opt/IBM/WebSphere/Liberty20009/usr/servers/Liberty_20009_server/server.xml && echo "files are the same, proceed to the next step"
 ```
 
 * Confirm that the Liberty server is registered to WebSphere Automation


### PR DESCRIPTION
- Added disclaimer to the `cp` command
- Added `cp -f` to force the copy command (If the destination file cannot be opened, remove it and create a new file, without prompting for confirmation regardless of its permissions.) 
- RHEL has an alias for `cp` (ie. `cp='cp -i'`), so adding `\cp` to use unalias version